### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "circomlibjs": "^0.0.8",
-    "snarkjs": "^0.4.10"
+    "circomlibjs": "0.0.8",
+    "snarkjs": "0.4.10"
   }
 }


### PR DESCRIPTION
ensure that circom references 0.0.8 and snarkjs references 0.4.10

> Note: there was a breaking change in snark.js recently that caused an issue in the proof generation.  It works with version 4.10 of snarkjs