### PR TITLE
update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "zk-lib-test2",
-  "version": "1.0.1",
+  "name": "zkp-merkle-airdrop-lib",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "zk-lib-test2",
-      "version": "1.0.1",
+      "name": "zkp-merkle-airdrop-lib",
+      "version": "1.0.2",
       "dependencies": {
-        "circomlibjs": "^0.0.8",
-        "snarkjs": "^0.4.10"
+        "circomlibjs": "0.0.8",
+        "snarkjs": "0.4.10"
       },
       "devDependencies": {
         "typescript": "^4.5.4"


### PR DESCRIPTION
Locks the `circomlibjs` and `snarkjs` package versions to match the change made in #3 